### PR TITLE
Addded name of package required for ALSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 * Linux
-* Alsa
+* Alsa (`libasound2-dev`)
 * Gtk+ 3.4 (`libgtk-3-dev`)
 * FFTW 3 (`libfftw3-dev`)
 


### PR DESCRIPTION
This package is necessary and was needed to be installed along with ALSA on Linux Mint.
I just used apt-file to find the package and add it. 